### PR TITLE
Use actions/upload-artifact@v4 in GHA workflow

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -10,11 +10,10 @@ jobs:
         run: ./pleasew test --log_file plz-out/log/test.log
       - name: Archive logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: logs
-          path: |
-            plz-out/log
+          path: plz-out/log
   release:
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
actions/upload-artifact@v2 is deprecated and workflows aren't able to use it any more.